### PR TITLE
 Update OpenCon2017 Cambridge blurb

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
 <title>OpenConCam</title>
-<meta http-equiv="Content-Type" content="text/html;charset=iso-8859-1"/>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
 <meta name="title" content="OpenCon Cambridge"/>
 <meta name="author" content="Laurent Gatto and OpenConCam"/>
 <meta name="keywords" content=""/>
@@ -45,23 +45,35 @@
 
       <h2>Activities</h2>
 
-      <p><strong>SAVE THE DATE: OpenCon Cambridge 2017</strong></p>
+      <p><strong>OpenCon Cambridge 2017</strong></p>
 
-      <p>16-17 November, Betty and Gordon Moore Library, University of
-      Cambridge. <b><a href="http://www.opencon2017.org/lgatt0/opencon_2017_cambridge">Book
-      your place here.</a></b> Speakers and details to follow
-      shortly!</p>
+      <p><em>16 November, Betty and Gordon Moore Library, University of
+      Cambridge.</em> <b><a href="http://www.opencon2017.org/lgatt0/opencon_2017_cambridge">Book
+      your place, and see details of speakers here.</a></b></p>
 
-      <p><a href="http://www.opencon2017.org/">OpenCon 2017</a> is the
-      student and early career academic professional conference on
-      Open Access, Open Education and Open Data, this year being held
-      from 11-13 November in Berlin, Germany. OpenCon Cambridge is a
-      satellite event that will bring together students, early career
-      academic researchers and open advocates from around Cambridge
-      and beyond! The theme of this year is Making Open Work for
-      Everyone, featuring a series of talks and discussions.</p>
-	    <p>We're grateful to <a href="https://peerj.com/">PeerJ</a> and <a href="https://github.com/open-contracting/sample-data/tree/master/real-examples">Arcadia</a>
+      <p>OpenCon 2017 is the student and early career academic professional
+      conference on Open Access, Open Education, and Open Data being held in
+      Berlin 11-13 Nov 2017.</p>
+
+      <p>The <strong><a
+      href="http://www.opencon2017.org/lgatt0/opencon_2017_cambridge">OpenCon
+      2017 Cambridge</a></strong> satellite event on 16 Nov 2017 will bring
+      together students, early career academic professionals and open advocates
+      from around Cambridge (although anyone is welcome to join us!).</p>
+
+      <p>This year's OpenCon theme is “<strong>Open in order to...</strong>”
+      and the OpenConCam’s theme is <strong>‘Open for everyone’.</strong>. Our
+      goal is to support and build the open community in Cambridge. We want to
+      empower attendees<strong> whatever their background</strong> to
+      <strong>make a difference</strong> in their respective fields through
+      open research, data, education and access and ensure that that difference
+      is inclusive.</p>
+
+	    <p>We're grateful to <a href="https://peerj.com/"><strong>PeerJ</strong></a> and <a href="https://github.com/open-contracting/sample-data/tree/master/real-examples"><strong>Arcadia</strong></a>
 		    for their support which keeps the cost low for all participants.</p>
+
+      <p>&nbsp;</p>
+    
       <p>
         <strong>
           Monthly meetings

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       academic researchers and open advocates from around Cambridge
       and beyond! The theme of this year is Making Open Work for
       Everyone, featuring a series of talks and discussions.</p>
-	    <p>We're grateful to [PeerJ](https://peerj.com/) and [Arcadia](https://www.arcadiafund.org.uk/) 
+	    <p>We're grateful to <a href="https://peerj.com/">PeerJ</a> and <a href="https://github.com/open-contracting/sample-data/tree/master/real-examples">Arcadia</a>
 		    for their support which keeps the cost low for all participants.</p>
       <p>
         <strong>


### PR DESCRIPTION
Note: http://www.opencon2017.org/lgatt0/opencon_2017_cambridge also still says November 16-17 in the top right corner.